### PR TITLE
Fix typo in README heading from 'Vite' to 'VitE'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React + Vite
+# React + VitE
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 


### PR DESCRIPTION
@